### PR TITLE
Add missing bracket

### DIFF
--- a/R/sumer.R
+++ b/R/sumer.R
@@ -37,7 +37,7 @@ sumer <- function(config_file, output_dir, n_threads=4){
   all_platform_abbr <- c()
 
   # plot the original data
-  all_data <- data.frame(platfrom=character(), name=character(), size=integer(), score=numeric)
+  all_data <- data.frame(platfrom=character(), name=character(), size=integer(), score=numeric())
 
   # save the name of output directory for each platform
   work_dirs <- list()


### PR DESCRIPTION
Running a test example:
```{R}
setwd(here())
file.copy(system.file("data", "sample.tgz", package = "sumer"), ".")  
untar("sample.tgz")  
sumer("config.json", "output")
```
throws an error:
`Error in as.data.frame.default(x[[i]], optional = TRUE) : cannot coerce class ‘"function"’ to a data.frame`
tracing back to line 40 in `sumer.R`:
`all_data <- data.frame(platfrom=character(), name=character(), size=integer(), score=numeric)`.
Adding `()` after `numeric` fixed the issue.